### PR TITLE
fix #10 VSCode で正常にファイルを開けるように

### DIFF
--- a/bson/fromBsonBinary.ts
+++ b/bson/fromBsonBinary.ts
@@ -51,7 +51,9 @@ export const fromBsonBinary = (
   binary: Uint8Array,
 ): DocumentWithError => {
   return documentFromDataView(
-    toReadonlyDataView(new DataView(binary.buffer)),
+    toReadonlyDataView(
+      new DataView(binary.buffer, binary.byteOffset, binary.byteLength),
+    ),
   );
 };
 


### PR DESCRIPTION
VSCode 内部で作られた Uint8Array の byteOffset は 0 でないことがある